### PR TITLE
added example help text for location override

### DIFF
--- a/src/pkjs/clay/config.js
+++ b/src/pkjs/clay/config.js
@@ -163,7 +163,10 @@ module.exports = [
                 "type": "input",
                 "label": "Location override",
                 "messageKey": "location",
-                "description": "Leave this blank to use GPS (ensure GPS is enabled if left blank), example: 40.758896,-73.985130"
+                "description": "Example: \"Manhattan\" or \"123 Oak St Plainsville KY\".<br><a href=\"https://locationiq.com/#demo\">Click here</a> to test out your location query.<br>To use GPS, leave this blank and ensure GPS is enabled on your device.",
+                "attributes": {
+                    "placeholder": "Using GPS",
+                }
             }
         ]
     },

--- a/src/pkjs/clay/config.js
+++ b/src/pkjs/clay/config.js
@@ -163,7 +163,7 @@ module.exports = [
                 "type": "input",
                 "label": "Location override",
                 "messageKey": "location",
-                "description": "Leave this blank to use GPS"
+                "description": "Leave this blank to use GPS (ensure GPS is enabled if left blank), example: 40.758896,-73.985130"
             }
         ]
     },


### PR DESCRIPTION
Example lat/long is Manhattan from https://www.latlong.net/place/times-square-manhattan-nyc-usa-7560.html