### PR TITLE
fix: Add language param to Wunderground_Forecast

### DIFF
--- a/src/pkjs/weather/wunderground.js
+++ b/src/pkjs/weather/wunderground.js
@@ -21,7 +21,7 @@ WundergroundProvider.prototype._super = WeatherProvider;
 
 WundergroundProvider.prototype.withWundergroundForecast = function(lat, lon, apiKey, callback) {
     // callback(wundergroundResponse)
-    var url = 'https://api.weather.com/v1/geocode/' + lat + '/' + lon + '/forecast/hourly/48hour.json?apiKey=' + apiKey;
+    var url = 'https://api.weather.com/v1/geocode/' + lat + '/' + lon + '/forecast/hourly/48hour.json?apiKey=' + apiKey + '&language=en-US';
 
     console.log("Requesting " + url)
 


### PR DESCRIPTION
fixes #75

I am currently not able to build and test. I only checked it in the browser and did not search through the `.c` code. But I think that it is not required